### PR TITLE
Add verification for google search console

### DIFF
--- a/header.inc.php
+++ b/header.inc.php
@@ -10,6 +10,7 @@
     <meta name="description" content="qBittorrent Official Website"/>
     <meta name="keywords" content="qBittorrent, torrent client, BitTorrent protocol, cross-platform, free and open-source software, GNU GPL, libtorrent-rasterbar, Qt, C++"/>
     <meta name="author" content="qBittorrent Development Team: https://github.com/qbittorrent"/>
+    <meta name="google-site-verification" content="2P14de1zV_NTk03Ebnc0wpPKWaeJoj7B9Tc_HtRkOfE" />
 
     <title>qBittorrent Official Website</title>
 


### PR DESCRIPTION
@sledgehammer999 
I'm trying to learn more about **how google sees the site** and seek improvement, thus I need to add a `meta` tag in order to pass the verification (proves that I am the webmaster).
This is **NOT** the same as google analytics which collects user data.
https://support.google.com/webmasters/answer/4559176

Reason: google currently shows this when I use "qBittorrent" as search keyword:
```
qBittorrent Official Website
https://www.qbittorrent.org/
Free software released under the GNU GPL license. Intended for Linux users.
```
And you see the 3rd line is not entirely true (the linux part should be cross-platform), I'm trying to change that.


ps. The `meta` tag needs to stay in order to stay verified.
